### PR TITLE
Add error when loading object with unregisterd constructor

### DIFF
--- a/src/main/coffee/arya.coffee
+++ b/src/main/coffee/arya.coffee
@@ -97,10 +97,13 @@ class Arya
       else
         if dObj[TYPE_TAG]?
           rObjCons = @_constructors[dObj[TYPE_TAG]]
-          if rObjCons.__proxy
-            context[uuid] = rObjCons(dObj, json, uuid, context)
+          if rObjCons?
+            if rObjCons.__proxy
+              context[uuid] = rObjCons(dObj, json, uuid, context)
+            else
+              context[uuid] = new rObjCons()
           else
-            context[uuid] = new rObjCons()
+            return next new Error("Unregisterd constructor " + dObj[TYPE_TAG]);
         else
           context[uuid] = {}
       # now let's rehydrate the provided JSON into the canonical object


### PR DESCRIPTION
This patch calls the callback function with an error object when loading an object who's constructor is not registered. The use case for this is for supporting old persistence files when removing classes from a codebase.

I am _not_ a coffee coder and have not even attempted to compile this. I have made the edits in my local JavaScript file to test. Please test carefully.
